### PR TITLE
Chore/add ssr styled component nextjs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": ["next/babel"],
+  "plugins": [
+    ["babel-plugin-styled-components", { "ssr": true, "displayName": true, "preprocess": false }]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/react": "^16.9.16",
     "@types/react-dom": "^16.9.4",
     "@types/styled-components": "^5.1.7",
+    "babel-plugin-styled-components": "^1.12.0",
     "eslint": "^7.18.0",
     "husky": "^4.3.8",
     "lint-staged": "^10.5.3",

--- a/src/components/atoms/Input/index.tsx
+++ b/src/components/atoms/Input/index.tsx
@@ -30,7 +30,6 @@ export interface IInputProps {
   padding?: string;
   border?: string;
   color?: string;
-  pointer?: boolean;
   opacity?: number;
 }
 

--- a/src/components/atoms/Input/style.ts
+++ b/src/components/atoms/Input/style.ts
@@ -14,7 +14,6 @@ export const WrapInput = styled.input<IInputProps>`
   border: ${props => props.border && props.border};
   color: ${props => props.color && props.color};
   opacity: ${props => props.opacity && props.opacity};
-  cursor: ${props => (props.pointer ? 'pointer' : 'default')};
   font: ${props => props.font && props.theme.fonts[props.font]};
 
   border-radius: 2px;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,51 @@
+// import * as React from 'react';
+import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
+
+interface StyledProps {
+  styleTags: Array<React.ReactElement<{}>>;
+}
+
+class MyDocument extends Document<StyledProps> {
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+    const initialProps = await Document.getInitialProps(ctx);
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: App => props => sheet.collectStyles(<App {...props} />),
+        });
+
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } catch (error) {
+      console.error(error);
+    } finally {
+      sheet.seal();
+    }
+    console.error('return Origin initialProps');
+    return initialProps;
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,4 +1,3 @@
-// import * as React from 'react';
 import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 


### PR DESCRIPTION
resolved #15 

1. nextjs에서 styled-components를 사용하려면 'babel-plugin-styled-components' 라이브러리가 필요함
2. .babelrc 설정 파일에서 플러그인 등록하고 ssr 옵션 true로 변경
3. _document.tsx 파일에 style을 ssr로 넣어주는 설정 추가